### PR TITLE
validate that json is concrete

### DIFF
--- a/pkg/schema/validation/validate.go
+++ b/pkg/schema/validation/validate.go
@@ -39,9 +39,11 @@ func (c configValidator) Validate(b []byte, key string) error {
 		c.logger.WithError(err).Debugf(key)
 		return err
 	}
-
-	err = json.Validate(b, v)
+	jsonAsCue, err := json.Decode(c.runtime, c.instance.Dir, b)
 	if err != nil {
+		return fmt.Errorf("could not parse json: %v", err)
+	}
+	if err := v.Unify(jsonAsCue.Value()).Validate(cue.Concrete(true)); err != nil {
 		c.logger.WithError(err).Debugf("Validation error")
 		return err
 	}

--- a/pkg/schema/validation/validate_test.go
+++ b/pkg/schema/validation/validate_test.go
@@ -127,32 +127,34 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		logger := logrus.NewEntry(logrus.New())
-		// load schema for config definitions
-		instance := load.Instances([]string{"."}, &load.Config{
-			Dir: schemaPath,
-		})
-		if len(instance) > 1 {
-			t.Fatalf("multiple instance loading currently not supported: %s", schemaPath)
-		}
-		if len(instance) < 1 {
-			t.Fatalf("no instances found: %s", schemaPath)
-		}
+		t.Run(tt.description, func(t *testing.T) {
+			logger := logrus.NewEntry(logrus.New())
+			// load schema for config definitions
+			instance := load.Instances([]string{"."}, &load.Config{
+				Dir: schemaPath,
+			})
+			if len(instance) > 1 {
+				t.Fatalf("multiple instance loading currently not supported: %s", schemaPath)
+			}
+			if len(instance) < 1 {
+				t.Fatalf("no instances found: %s", schemaPath)
+			}
 
-		// Config validator
-		configValidator := NewConfigValidator(instance[0], logger)
-		// Read json file
-		content, err := ioutil.ReadFile(tt.filename)
-		require.NoError(t, err)
-
-		// Validate json against schema
-		err = configValidator.Validate(content, tt.kind)
-
-		if tt.hasError {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.errString)
-		} else {
+			// Config validator
+			configValidator := NewConfigValidator(instance[0], logger)
+			// Read json file
+			content, err := ioutil.ReadFile(tt.filename)
 			require.NoError(t, err)
-		}
+
+			// Validate json against schema
+			err = configValidator.Validate(content, tt.kind)
+
+			if tt.hasError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errString)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }

--- a/vendor/cuelang.org/go/pkg/encoding/json/manual.go
+++ b/vendor/cuelang.org/go/pkg/encoding/json/manual.go
@@ -119,8 +119,5 @@ func Validate(b []byte, v cue.Value) (bool, error) {
 	if v.Err() != nil {
 		return false, v.Err()
 	}
-	if err := v.Validate(cue.Concrete(true)); err != nil {
-		return false, err
-	}
 	return true, nil
 }


### PR DESCRIPTION
this avoids the need to use a forked cue

Signed-off-by: Evan Cordell <cordell.evan@gmail.com>